### PR TITLE
Get CVPixelBuffer from rtsp streaming with input frame is ffmpeg's AV…

### DIFF
--- a/ijkmedia/ijksdl/ijksdl_vout.h
+++ b/ijkmedia/ijksdl/ijksdl_vout.h
@@ -49,6 +49,12 @@ struct SDL_VoutOverlay {
     SDL_Class               *opaque_class;
     SDL_VoutOverlay_Opaque  *opaque;
 
+    // Use to get video frame in Objective C
+    // Equal to opaque.linked_frame (ijksdl_vout_overlay_ffmpeg)
+    // Use videotoolbox cause black twinkling frame on stream view
+    // and sometime, app will crash without log ???
+    AVFrame *video_frame;
+    
     void    (*free_l)(SDL_VoutOverlay *overlay);
     int     (*lock)(SDL_VoutOverlay *overlay);
     int     (*unlock)(SDL_VoutOverlay *overlay);

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
@@ -99,6 +99,7 @@ typedef enum IJKLogLevel {
 - (void)keepPlayStreamWhenResignActive:(BOOL)keepPlay;
 
 - (void)setHudValue:(NSString *)value forKey:(NSString *)key;
+@property (nonatomic, copy) GetPixelBufferRef getPixelBuffer;
 
 + (void)setLogReport:(BOOL)preferLogReport;
 + (void)setLogLevel:(IJKLogLevel)logLevel;

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -214,6 +214,7 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
 
         // init video sink
         _glView = [[IJKSDLGLView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+        [self handleCVPixelBufferFrame:_glView];
         _glView.isThirdGLView = NO;
         _view = _glView;
         _hudViewController = [[IJKSDLHudViewController alloc] init];
@@ -1809,5 +1810,11 @@ static int ijkff_inject_callback(void *opaque, int message, void *data, size_t d
     }
 }
 
+- (void)handleCVPixelBufferFrame:(IJKSDLGLView *)glView {
+    __weak __typeof__(self) weakSelf = self;
+    glView.getPixelBuffer = ^(CVPixelBufferRef pixelBuffer) {
+        weakSelf.getPixelBuffer(pixelBuffer);
+    };
+}
 @end
 

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
@@ -65,6 +65,8 @@ typedef NS_ENUM(NSInteger, IJKMPMovieTimeOption) {
 
 #pragma mark IJKMediaPlayback
 
+typedef void(^GetPixelBufferRef)(CVPixelBufferRef pixelBuffer);
+
 @protocol IJKMediaPlayback <NSObject>
 
 - (void)prepareToPlay;
@@ -102,6 +104,7 @@ typedef NS_ENUM(NSInteger, IJKMPMovieTimeOption) {
 @property (nonatomic) float playbackRate;
 @property (nonatomic) float playbackVolume;
 
+@property (nonatomic, copy) GetPixelBufferRef getPixelBuffer;
 
 - (UIImage *)thumbnailImageAtCurrentTime;
 

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKSDLGLViewProtocol.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKSDLGLViewProtocol.h
@@ -39,8 +39,13 @@ struct IJKOverlay {
     CVPixelBufferRef pixel_buffer;
 };
 
+typedef void(^GetPixelBufferRef)(CVPixelBufferRef pixelBuffer);
+
 @protocol IJKSDLGLViewProtocol <NSObject>
 - (UIImage*) snapshot;
+
+@property (nonatomic, copy) GetPixelBufferRef getPixelBuffer;
+
 @property(nonatomic, readonly) CGFloat  fps;
 @property(nonatomic)        CGFloat  scaleFactor;
 @property(nonatomic)        BOOL  isThirdGLView;

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.h
@@ -30,6 +30,7 @@
 
 @interface IJKSDLGLView : UIView <IJKSDLGLViewProtocol>
 
+@property (nonatomic, copy) GetPixelBufferRef getPixelBuffer;
 - (id) initWithFrame:(CGRect)frame;
 - (void) display: (SDL_VoutOverlay *) overlay;
 - (void) keepPlayStreamWhenResignActive:(BOOL)keepPlay;


### PR DESCRIPTION
Get CVPixelBuffer from rtsp streaming with input frame is ffmpeg's AVFrame

If using videotoolbox, we can get pixel_buffer in struct IJKOverlay, property CVPixelBufferRef pixel_buffer;
But when using videotoolbox, streaming become twinkling frame on stream view, and sometime crashed without any clue.

In IJKSDLGLView, we send CVPixelBuffer to other view controller, then we can use this buffer to display streaming data on other OpenGL ES or Metal view, or input to GPUImage, so IJKSDLGLView is not really needed, we will remove this view in next commit.